### PR TITLE
fixing issue where current user is a default reviewer

### DIFF
--- a/examples/go/upgrade-go-version.sh
+++ b/examples/go/upgrade-go-version.sh
@@ -2,5 +2,5 @@
 
 # Title: Upgrade Go version in go modules
 
-go mod edit -go 1.19
+go mod edit -go 1.20
 go mod tidy

--- a/examples/go/upgrade-go-version.sh
+++ b/examples/go/upgrade-go-version.sh
@@ -2,5 +2,5 @@
 
 # Title: Upgrade Go version in go modules
 
-go mod edit -go 1.20
+go mod edit -go 1.19
 go mod tidy


### PR DESCRIPTION
There is a bug where if your current user is part of the default reviewers bitbucket returns a 400, this makes sense since you can't be a reviewer on your own PR.

In this case we want to exclude a reviewer if it is the same as the current user who is creating the PR.