### PR TITLE
Fix create pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,9 +1022,3 @@ replace();
 
 
 Do you have a nice script that might be useful to others? Please create a PR that adds it to the [examples folder](/examples).
-
-## Bitbucket Cloud Support
-Using `fork: true` is currently experimental within multi-gitter for Bitbucket Cloud, and will be addressed in future updates.
-Here are the known limitations:
-- The forked repository will appear in the user-provided workspace/orgName, with the given repo name, but will appear in a random project within that workspace.
-- Using `git-type: cmd` is required for Bitbucket Cloud forking, as `git-type: go` causes inconsistent behavior. 

--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -23,7 +23,7 @@ func configurePlatform(cmd *cobra.Command) {
 	flags.StringP("base-url", "g", "", "Base URL of the target platform, needs to be changed for GitHub enterprise, a self-hosted GitLab instance, Gitea or BitBucket.")
 	flags.BoolP("insecure", "", false, "Insecure controls whether a client verifies the server certificate chain and host name. Used only for Bitbucket server.")
 	flags.StringP("username", "u", "", "The Bitbucket server username.")
-	flags.StringP("token", "T", "", "The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN environment variable.")
+	flags.StringP("token", "T", "", "The personal access token for the targeting platform. Can also be set using the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN/BITBUCKET_CLOUD_APP_PASSWORD environment variable.")
 
 	flags.StringSliceP("org", "O", nil, "The name of a GitHub organization. All repositories in that organization will be used.")
 	flags.StringSliceP("group", "G", nil, "The name of a GitLab organization. All repositories in that group will be used.")

--- a/docs/README.template.md
+++ b/docs/README.template.md
@@ -132,3 +132,27 @@ All configuration in multi-gitter can be done through command line flags, config
 {{end}}{{end}}
 
 Do you have a nice script that might be useful to others? Please create a PR that adds it to the [examples folder](/examples).
+
+## Bitbucket Cloud
+
+In order to use bitbucket cloud you will need to create and use an [App Password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/). The app password you create needs sufficient permissions so ensure you grant it Read and Write access to projects, repositories and pull requests and at least Read access to your account and workspace membership.
+
+You will need to configure the bitbucket workspace using the `org` option for multi-gitter for the repositories you want to make changes to e.g. `multi-gitter run examples/go/upgrade-go-version.sh -u your_username --org "your_workspace"`
+
+### Example
+Here is an example of using the command line options to run a script from the `examples/` directory and make pull-requests for a few repositories in a specified workspace.
+```shell
+export BITBUCKET_CLOUD_APP_PASSWORD="your_app_password"
+multi-gitter run examples/go/upgrade-go-version.sh -u your_username --org "your_workspace" --repo "your_first_repository,your_second_repository" --platform bitbucket_cloud -m "your_commit_message" -B your_branch_name
+```
+
+### Bitbucket Cloud Limitations
+Currently, we add the repositories default reviewers as a reviewer for any pull-request you create. If you want to specify specific reviewers, you will need to add them using their `UUID` instead of their username since bitbucket does not allow us to look up a `UUID` using their username. [This article has more information about where you can get a users UUID.](https://community.atlassian.com/t5/Bitbucket-articles/Retrieve-the-Atlassian-Account-ID-AAID-in-bitbucket-org/ba-p/2471787)
+
+We don't support specifying specific projects for bitbucket cloud yet, you should still be able to make changes to the repositories you want but certain functionality, like forking, does not work as well until we implement that feature.
+Using `fork: true` is currently experimental within multi-gitter for Bitbucket Cloud, and will be addressed in future updates.
+Here are the known limitations:
+- The forked repository will appear in the user-provided workspace/orgName, with the given repo name, but will appear in a random project within that workspace.
+- Using `git-type: cmd` is required for Bitbucket Cloud forking for now until better support is added, as `git-type: go` causes inconsistent behavior(intermittent unauthorized errors).
+
+We also only support modifying a single workspace, any additional workspaces passed into the multi-gitter `org` option will be ignored after the first value.

--- a/examples/go/upgrade-go-version.sh
+++ b/examples/go/upgrade-go-version.sh
@@ -2,5 +2,5 @@
 
 # Title: Upgrade Go version in go modules
 
-go mod edit -go 1.20
+go mod edit -go 1.19
 go mod tidy

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -252,11 +252,10 @@ func (bbc *BitbucketCloud) GetOpenPullRequest(ctx context.Context, repo scm.Repo
 
 func (bbc *BitbucketCloud) MergePullRequest(ctx context.Context, pr scm.PullRequest) error {
 	bbcPR := pr.(pullRequest)
-	repoSlug := strings.Split(bbcPR.guiURL, "/")[4]
 	prOptions := &bitbucket.PullRequestsOptions{
 		ID:           fmt.Sprintf("%d", bbcPR.number),
 		SourceBranch: bbcPR.branchName,
-		RepoSlug:     repoSlug,
+		RepoSlug:     bbcPR.prRepoName,
 		Owner:        bbc.workspaces[0],
 	}
 	_, err := bbc.bbClient.Repositories.PullRequests.Merge(prOptions)
@@ -265,11 +264,10 @@ func (bbc *BitbucketCloud) MergePullRequest(ctx context.Context, pr scm.PullRequ
 
 func (bbc *BitbucketCloud) ClosePullRequest(ctx context.Context, pr scm.PullRequest) error {
 	bbcPR := pr.(pullRequest)
-	repoSlug := strings.Split(bbcPR.guiURL, "/")[4]
 	prOptions := &bitbucket.PullRequestsOptions{
 		ID:           fmt.Sprintf("%d", bbcPR.number),
 		SourceBranch: bbcPR.branchName,
-		RepoSlug:     repoSlug,
+		RepoSlug:     bbcPR.prRepoName,
 		Owner:        bbc.workspaces[0],
 	}
 	_, err := bbc.bbClient.Repositories.PullRequests.Decline(prOptions)

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -164,7 +164,6 @@ func (bbc *BitbucketCloud) GetPullRequests(ctx context.Context, branchName strin
 			responsePRs = append(responsePRs, convertedPr)
 		}
 	}
-	fmt.Println(responsePRs)
 	return responsePRs, nil
 }
 

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -64,7 +64,10 @@ func (bbc *BitbucketCloud) CreatePullRequest(ctx context.Context, repo scm.Repos
 	if err != nil {
 		return nil, err
 	}
-	defaultReviewers, _ := bbc.bbClient.Repositories.Repository.ListDefaultReviewers(repoOptions)
+	defaultReviewers, err := bbc.bbClient.Repositories.Repository.ListDefaultReviewers(repoOptions)
+	if err != nil {
+		return nil, err
+	}
 	for _, reviewer := range defaultReviewers.DefaultReviewers {
 		if currentUser.Uuid != reviewer.Uuid {
 			newPR.Reviewers = append(newPR.Reviewers, reviewer.Uuid)
@@ -140,10 +143,16 @@ func (bbc *BitbucketCloud) UpdatePullRequest(ctx context.Context, repo scm.Repos
 func (bbc *BitbucketCloud) GetPullRequests(ctx context.Context, branchName string) ([]scm.PullRequest, error) {
 	var responsePRs []scm.PullRequest
 	for _, repoName := range bbc.repositories {
-		prs, _ := bbc.bbClient.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{Owner: bbc.workspaces[0], RepoSlug: repoName})
-		prBytes, _ := json.Marshal(prs)
+		prs, err := bbc.bbClient.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{Owner: bbc.workspaces[0], RepoSlug: repoName})
+		if err != nil {
+			return nil, err
+		}
+		prBytes, err := json.Marshal(prs)
+		if err != nil {
+			return nil, err
+		}
 		bbPullRequests := &bitbucketPullRequests{}
-		err := json.Unmarshal(prBytes, bbPullRequests)
+		err = json.Unmarshal(prBytes, bbPullRequests)
 		if err != nil {
 			return nil, err
 		}
@@ -162,10 +171,16 @@ func (bbc *BitbucketCloud) GetPullRequests(ctx context.Context, branchName strin
 func (bbc *BitbucketCloud) getPullRequests(ctx context.Context, repoName string) ([]pullRequest, error) {
 
 	var repoPRs []pullRequest
-	prs, _ := bbc.bbClient.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{Owner: bbc.workspaces[0], RepoSlug: repoName})
-	prBytes, _ := json.Marshal(prs)
+	prs, err := bbc.bbClient.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{Owner: bbc.workspaces[0], RepoSlug: repoName})
+	if err != nil {
+		return nil, err
+	}
+	prBytes, err := json.Marshal(prs)
+	if err != nil {
+		return nil, err
+	}
 	bbPullRequests := &bitbucketPullRequests{}
-	err := json.Unmarshal(prBytes, bbPullRequests)
+	err = json.Unmarshal(prBytes, bbPullRequests)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +228,10 @@ func (bbc *BitbucketCloud) pullRequestStatus(pr *bbPullRequest) (scm.PullRequest
 func (bbc *BitbucketCloud) GetOpenPullRequest(ctx context.Context, repo scm.Repository, branchName string) (scm.PullRequest, error) {
 	repoFN := repo.FullName()
 	repoSlug := strings.Split(repoFN, "/")
-	repoPRs, _ := bbc.getPullRequests(ctx, repoSlug[1])
+	repoPRs, err := bbc.getPullRequests(ctx, repoSlug[1])
+	if err != nil {
+		return nil, err
+	}
 	for _, repoPR := range repoPRs {
 		pr := pullRequest(repoPR)
 		if pr.branchName == branchName && pr.status == scm.PullRequestStatusSuccess {
@@ -303,7 +321,10 @@ func (bbc *BitbucketCloud) convertRepository(repo bitbucket.Repository) (*reposi
 	var cloneURL string
 
 	rLinks := &repoLinks{}
-	linkBytes, _ := json.Marshal(repo.Links)
+	linkBytes, err := json.Marshal(repo.Links)
+	if err != nil {
+		return nil, err
+	}
 	_ = json.Unmarshal(linkBytes, rLinks)
 
 	if bbc.sshAuth {

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -252,10 +252,11 @@ func (bbc *BitbucketCloud) GetOpenPullRequest(ctx context.Context, repo scm.Repo
 
 func (bbc *BitbucketCloud) MergePullRequest(ctx context.Context, pr scm.PullRequest) error {
 	bbcPR := pr.(pullRequest)
+	repoSlug := strings.Split(bbcPR.guiURL, "/")[4]
 	prOptions := &bitbucket.PullRequestsOptions{
 		ID:           fmt.Sprintf("%d", bbcPR.number),
 		SourceBranch: bbcPR.branchName,
-		RepoSlug:     bbcPR.prRepoName,
+		RepoSlug:     repoSlug,
 		Owner:        bbc.workspaces[0],
 	}
 	_, err := bbc.bbClient.Repositories.PullRequests.Merge(prOptions)
@@ -264,10 +265,11 @@ func (bbc *BitbucketCloud) MergePullRequest(ctx context.Context, pr scm.PullRequ
 
 func (bbc *BitbucketCloud) ClosePullRequest(ctx context.Context, pr scm.PullRequest) error {
 	bbcPR := pr.(pullRequest)
+	repoSlug := strings.Split(bbcPR.guiURL, "/")[4]
 	prOptions := &bitbucket.PullRequestsOptions{
 		ID:           fmt.Sprintf("%d", bbcPR.number),
 		SourceBranch: bbcPR.branchName,
-		RepoSlug:     bbcPR.prRepoName,
+		RepoSlug:     repoSlug,
 		Owner:        bbc.workspaces[0],
 	}
 	_, err := bbc.bbClient.Repositories.PullRequests.Decline(prOptions)

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -2,13 +2,14 @@ package bitbucketcloud
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
+
+	internalHTTP "github.com/lindell/multi-gitter/internal/http"
 
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/lindell/multi-gitter/internal/scm"
@@ -43,9 +44,7 @@ func New(username string, token string, repositories []string, workspaces []stri
 	bitbucketCloud.sshAuth = sshAuth
 	bitbucketCloud.newOwner = newOwner
 	bitbucketCloud.httpClient = &http.Client{
-		Transport: transportMiddleware(&http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: false}, // nolint: gosec
-		}),
+		Transport: internalHTTP.LoggingRoundTripper{},
 	}
 	bitbucketCloud.bbClient = bitbucket.NewBasicAuth(username, token)
 

--- a/internal/scm/bitbucketcloud/bitbucket_cloud.go
+++ b/internal/scm/bitbucketcloud/bitbucket_cloud.go
@@ -157,7 +157,7 @@ func (bbc *BitbucketCloud) GetPullRequests(ctx context.Context, branchName strin
 	}
 	for _, repo := range repositories {
 		bbcRepo := repo.(repository)
-		prs, err := bbc.bbClient.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{Owner: bbc.workspaces[0], RepoSlug: bbcRepo.name})
+		prs, err := bbc.bbClient.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{Owner: bbc.workspaces[0], RepoSlug: bbcRepo.name, SourceBranch: branchName})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/scm/bitbucketcloud/custom_structs.go
+++ b/internal/scm/bitbucketcloud/custom_structs.go
@@ -15,7 +15,7 @@ const (
 )
 
 type newPrResponse struct {
-	ID    int   `json:"id""`
+	ID    int   `json:"id"`
 	Links links `json:"links"`
 }
 

--- a/internal/scm/bitbucketcloud/custom_structs.go
+++ b/internal/scm/bitbucketcloud/custom_structs.go
@@ -2,7 +2,7 @@ package bitbucketcloud
 
 import (
 	"fmt"
-	
+
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/lindell/multi-gitter/internal/scm"
 )
@@ -14,39 +14,44 @@ const (
 	stateDeclined = "DECLINED"
 )
 
+type newPrResponse struct {
+	ID    int   `json:"id""`
+	Links links `json:"links"`
+}
+
 type bitbucketPullRequests struct {
-	Next		string			`json:"next"`
-	Page		int				`json:"page"`
-	PageLen 	int				`json:"pagelen"`
-	Previous 	string			`json:"previous"`
-	Size		int				`json:"size"`
-	Values 		[]bbPullRequest `json:"values"`
+	Next     string          `json:"next"`
+	Page     int             `json:"page"`
+	PageLen  int             `json:"pagelen"`
+	Previous string          `json:"previous"`
+	Size     int             `json:"size"`
+	Values   []bbPullRequest `json:"values"`
 }
 
 type bbPullRequest struct {
-	State		string			`json:"state"`
-	Source 		pullRequestRef	`json:"source"`
-	Destination pullRequestRef	`json:"destination"`
-	Links 		links 			`json:"links"`
-	Title 		string			`json:"title"`
-	Type 		string 			`json:"type"`
-	ID 			int				`json:"id"`
+	State       string         `json:"state"`
+	Source      pullRequestRef `json:"source"`
+	Destination pullRequestRef `json:"destination"`
+	Links       links          `json:"links"`
+	Title       string         `json:"title"`
+	Type        string         `json:"type"`
+	ID          int            `json:"id"`
 }
 
 type pullRequestRef struct {
-	Branch      branch     				`json:"branch"`
-	Commit 		commit 					`json:"Commit"`
-	Repository  bitbucket.Repository 	`json:"repository"`
+	Branch     branch               `json:"branch"`
+	Commit     commit               `json:"Commit"`
+	Repository bitbucket.Repository `json:"repository"`
 }
 
 type branch struct {
-	Name	string 	`json:"name"`
+	Name string `json:"name"`
 }
 
 type commit struct {
-	Hash 	string	`json:"hash"`
-	Type 	string 	`json:"type"`
-	Links 	links	`json:"links"`
+	Hash  string `json:"hash"`
+	Type  string `json:"type"`
+	Links links  `json:"links"`
 }
 
 type links struct {
@@ -56,8 +61,8 @@ type links struct {
 
 type repoLinks struct {
 	Clone []hrefLink `json:"clone,omitempty"`
-	Self []hrefLink `json:"self,omitempty"`
-	Html []hrefLink `json:"html,omitempty"`
+	Self  []hrefLink `json:"self,omitempty"`
+	Html  []hrefLink `json:"html,omitempty"`
 }
 
 type hrefLink struct {

--- a/internal/scm/bitbucketcloud/pullrequest.go
+++ b/internal/scm/bitbucketcloud/pullrequest.go
@@ -1,1 +1,0 @@
-package bitbucketcloud

--- a/internal/scm/bitbucketcloud/repository.go
+++ b/internal/scm/bitbucketcloud/repository.go
@@ -1,1 +1,0 @@
-package bitbucketcloud


### PR DESCRIPTION
This PR does some more cleanup and adds the ID and guiurl to a newly created or updated PR. I needed to add some minimal JSON marshaling and unmarshaling to parse the ID and guiurl.

I removed unused files.

I also updated the documentation and commandline options to mention bitbucket cloud configuration options and moved our documentation to the correct template section.